### PR TITLE
part5: update a todo

### DIFF
--- a/resources/api.controller.js
+++ b/resources/api.controller.js
@@ -1,5 +1,9 @@
 const index = require("../db/models/index");
 
+// chalkはコードの記述が終了次第消す
+// eslint-disable-next-line no-unused-vars
+const chalk = require("chalk");
+
 module.exports = {
   getTodos: async (req, res) => {
     try {
@@ -46,7 +50,7 @@ module.exports = {
     const t = await index.sequelize.transaction();
     try {
       const parseId = parseInt(req.params.id, 10);
-      if (typeof parseId !== "number" || parseId < 1) {
+      if (Number.isNaN(parseId) || parseId < 1) {
         throw new Error(
           "idに適切でない値が入っています、1以上の数字を入れてください"
         );

--- a/resources/api.controller.js
+++ b/resources/api.controller.js
@@ -61,8 +61,8 @@ module.exports = {
       ) {
         throw new Error("completedにはboolean型のみを入力してください");
       }
-      const findedTodo = index.Todo.findOne({
-        where: parseId,
+      const findedTodo = await index.Todo.findOne({
+        where: { id: parseId },
       });
       if (!findedTodo) {
         throw new Error(
@@ -92,11 +92,13 @@ module.exports = {
         completed = req.body.completed;
       }
 
-      const todo = await index.Todo.update(
+      await index.Todo.update(
         { title: title, body: body, completed: completed },
         { where: { id: parseId } },
         { t }
       );
+
+      const todo = await index.Todo.findOne({ where: { id: parseId } }, { t });
 
       await t.commit();
       res.status(200).json(todo);

--- a/resources/api.controller.js
+++ b/resources/api.controller.js
@@ -50,6 +50,15 @@ module.exports = {
           "idに適切でない値が入っています、1以上の数字を入れてください"
         );
       }
+      const todo = index.Todo.findOne({
+        where: parseId,
+      });
+      if (!todo) {
+        throw new Error(
+          `検索結果: ID:${parseId}に該当するTodoは見つかりませんでした`
+        );
+      }
+
       res.status(200).json();
     } catch (err) {
       res.status(400).json({ message: err.message });

--- a/resources/api.controller.js
+++ b/resources/api.controller.js
@@ -50,6 +50,9 @@ module.exports = {
           "idに適切でない値が入っています、1以上の数字を入れてください"
         );
       }
+      if (typeof req.body.completed !== "boolean") {
+        throw new Error("completedにはboolean型のみを入力してください");
+      }
       const todo = index.Todo.findOne({
         where: parseId,
       });

--- a/resources/api.controller.js
+++ b/resources/api.controller.js
@@ -1,9 +1,5 @@
 const index = require("../db/models/index");
 
-// chalkはコードの記述が終了次第消す
-// eslint-disable-next-line no-unused-vars
-const chalk = require("chalk");
-
 module.exports = {
   getTodos: async (req, res) => {
     try {

--- a/resources/api.controller.js
+++ b/resources/api.controller.js
@@ -53,10 +53,10 @@ module.exports = {
       if (typeof req.body.completed !== "boolean") {
         throw new Error("completedにはboolean型のみを入力してください");
       }
-      const todo = index.Todo.findOne({
+      const findedTodo = index.Todo.findOne({
         where: parseId,
       });
-      if (!todo) {
+      if (!findedTodo) {
         throw new Error(
           `検索結果: ID:${parseId}に該当するTodoは見つかりませんでした`
         );

--- a/resources/api.controller.js
+++ b/resources/api.controller.js
@@ -61,45 +61,22 @@ module.exports = {
       ) {
         throw new Error("completedにはboolean型のみを入力してください");
       }
-      const findedTodo = await index.Todo.findOne({
+      const todo = await index.Todo.findOne({
         where: { id: parseId },
       });
-      if (!findedTodo) {
+      if (!todo) {
         throw new Error(
           `検索結果: ID:${parseId}に該当するTodoは見つかりませんでした`
         );
       }
 
-      let title;
-      let body;
-      let completed;
-
-      if (!req.body.title) {
-        title = findedTodo.title;
-      } else {
-        title = req.body.title;
+      for (let prop in req.body) {
+        if (prop) {
+          todo[prop] = req.body[prop];
+        }
       }
 
-      if (!req.body.body) {
-        body = findedTodo.body;
-      } else {
-        body = req.body.body;
-      }
-
-      if (!req.body.completed) {
-        completed = findedTodo.completed;
-      } else {
-        completed = req.body.completed;
-      }
-
-      await index.Todo.update(
-        { title: title, body: body, completed: completed },
-        { where: { id: parseId } },
-        { t }
-      );
-
-      const todo = await index.Todo.findOne({ where: { id: parseId } }, { t });
-
+      await todo.save({ t });
       await t.commit();
       res.status(200).json(todo);
     } catch (err) {

--- a/resources/api.controller.js
+++ b/resources/api.controller.js
@@ -43,7 +43,11 @@ module.exports = {
     }
   },
   putTodo: (req, res) => {
-    res.status(200).send(`It's PUT request method ID: ${req.params.id}`);
+    try {
+      res.status(200).json();
+    } catch (err) {
+      res.status(400).json({ message: err.message });
+    }
   },
   deleteTodo: (req, res) => {
     res.status(200).send(`It's DELETE request method ID: ${req.params.id}`);

--- a/resources/api.controller.js
+++ b/resources/api.controller.js
@@ -44,6 +44,12 @@ module.exports = {
   },
   putTodo: (req, res) => {
     try {
+      const parseId = parseInt(req.params.id, 10);
+      if (typeof parseId !== "number" || parseId < 1) {
+        throw new Error(
+          "idに適切でない値が入っています、1以上の数字を入れてください"
+        );
+      }
       res.status(200).json();
     } catch (err) {
       res.status(400).json({ message: err.message });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 --recursive
 --exit
+--timeout [3000];

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
 --recursive
 --exit
---timeout [3000];

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -44,28 +44,31 @@ describe("TEST 「PUT /api/todos/:id」", () => {
   });
 
   it("idの引数に不正な値が入っていた場合、エラーが返る", async () => {
-    const invalidIdList = [
-      { id: 0 },
-      { id: -1 },
-      { id: "0" },
-      { id: true },
-      { id: undefined },
-      { id: null },
-      { id: [] },
-      { id: {} },
-    ];
-
+    const invalidIdList = [0, -1, "0", undefined, null, [], {}];
     const data = {
       title: "title",
       body: "body",
     };
 
     invalidIdList.forEach(async id => {
-      const response = updateTodo(400, data, id);
+      const response = await updateTodo(400, id, data);
       assert.strictEqual(
         response.body.message,
         "idに適切でない値が入っています、1以上の数字を入れてください"
       );
     });
+  });
+  it("idの引数と合致するTodoがない場合、エラーが返る", async () => {
+    const invalidId = 99999999999999999;
+    const data = {
+      title: "title",
+      body: "body",
+    };
+
+    const response = await updateTodo(400, id, data);
+    assert.strictEqual(
+      response.body.message,
+      `検索結果: ID${invalidId}に該当するTodoは見つかりませんでした`
+    );
   });
 });

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -7,8 +7,6 @@ const index = require("../../../../db/models/index");
 const DummyTodo = require("../../../../helper/createHelper");
 const requestHelper = require("../../../../helper/requestHelper").request;
 
-const chalk = require("chalk");
-
 const updateTodo = async (code, id, data) => {
   const response = await requestHelper({
     method: "put",

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -50,14 +50,23 @@ describe("TEST 「PUT /api/todos/:id」", () => {
       body: "body",
     };
 
-    invalidIdList.forEach(async id => {
-      const response = await updateTodo(400, id, data);
+    for (let i = 0; i < 5; i++) {
+      const response = await updateTodo(400, invalidIdList[i], data);
       assert.strictEqual(
         response.body.message,
         "idに適切でない値が入っています、1以上の数字を入れてください"
       );
-    });
+    }
+
+    // invalidIdList.forEach(async id => {
+    //   const response = await updateTodo(400, id, data);
+    //   assert.strictEqual(
+    //     response.body.message,
+    //     "idに適切でない値が入っています、1以上の数字を入れてください"
+    //   );
+    // });
   });
+
   it("idの引数と合致するTodoがない場合、エラーが返る", async () => {
     const invalidId = 99999999999999999;
     const data = {

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -103,7 +103,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
     }
   });
 
-  it("適切にデータを送った場合、idと合致したTodo一件のtitle、body、completed全て、またはいずれかが変更され返ってくる、また配列内にあったidと紐つくコメントは変更されたコメントに上書きされる", async () => {
+  it("適切にデータを送った場合、idと合致したTodo一件のtitle、body、completed全て、またはいずれかが変更され返ってくる、また配列内にあったidと紐つくTodoは変更されたTodoに上書きされる", async () => {
     const validId = 3;
 
     const oldTodo = await index.Todo.findOne({
@@ -126,6 +126,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
       const response = await updateTodo(200, validId, datas[i]);
       const todo = response.body;
 
+      // idと合致したTodo一件のtitle、body、completed全て、またはいずれかが変更され返ってくる
       if (datas[i].title && datas[i].body && datas[i].completed) {
         assert.deepStrictEqual(todo, {
           id: validId,
@@ -191,6 +192,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         });
       }
 
+      // 変更されたTodo１件のupdatedAtは更新されている
       assert.strictEqual(todo.updatedAt > todo.createdAt, true);
 
       const currentTodo = await index.Todo.findOne({
@@ -199,6 +201,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         },
       });
 
+      // 配列内にあったidと紐つくTodoは変更されたTodoに上書きされる
       assert.notStrictEqual(oldTodo, currentTodo);
     }
   });

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -191,7 +191,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         });
       }
 
-      assert.strictEqual(todo.updateAt > todo.createdAt, true);
+      assert.strictEqual(todo.updatedAt > todo.createdAt, true);
 
       const currentTodo = await index.Todo.findOne({
         where: {

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -35,20 +35,20 @@ describe("TEST 「PUT /api/todos/:id」", () => {
   });
 
   it("idの引数に不正な値が入っていた場合、エラーが返る", async () => {
-    const invalidIdList = [0, -1, "0", undefined, null, {}];
+    const invalidIdList = [0, -1, "0", undefined, null, {}, []];
     const data = {
       title: "title",
       body: "body",
     };
 
-    for (let i = 0; i < invalidIdList.length; i++) {
-      const response = await updateTodo(400, invalidIdList[i], data);
+    invalidIdList.forEach(async id => {
+      const response = await updateTodo(400, id, data);
 
       assert.strictEqual(
         response.body.message,
         "idに適切でない値が入っています、1以上の数字を入れてください"
       );
-    }
+    });
   });
 
   it("idの引数と合致するTodoがない場合、エラーが返る", async () => {
@@ -69,11 +69,11 @@ describe("TEST 「PUT /api/todos/:id」", () => {
     const invalidCompletedList = [-1, 2, "0", null, [], {}];
     const id = 3;
 
-    for (let i = 0; i < invalidCompletedList.length; i++) {
+    invalidCompletedList.forEach(async completed => {
       const data = {
         title: "title",
         body: "body",
-        completed: invalidCompletedList[i],
+        completed: completed,
       };
 
       const response = await updateTodo(400, id, data);
@@ -81,14 +81,14 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         response.body.message,
         "completedにはboolean型のみを入力してください"
       );
-    }
+    });
   });
 
   it("titleを更新した場合、データは適切に帰ってくる、また、DB内のデータも更新されている", done => {
     setTimeout(async () => {
       const validId = 3;
 
-      const oldTodo = await index.Todo.findOne({
+      const oldTodo = index.Todo.findOne({
         where: {
           id: validId,
         },
@@ -123,7 +123,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
       assert.notStrictEqual(oldTodo, currentTodo);
 
       done();
-    }, 100);
+    }, 10);
   });
   it("bodyを更新した場合、データは適切に帰ってくる、また、DB内のデータも更新されている", done => {
     setTimeout(async () => {
@@ -161,7 +161,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
       // 配列内にあったidと紐つくTodoは変更されたTodoに上書きされる
       assert.notStrictEqual(oldTodo, currentTodo);
       done();
-    }, 100);
+    }, 10);
   });
   it("completedを更新した場合、データは適切に帰ってくる、また、DB内のデータも更新されている", done => {
     setTimeout(async () => {
@@ -200,7 +200,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
       assert.notStrictEqual(oldTodo, currentTodo);
 
       done();
-    }, 100);
+    }, 10);
   });
   it("titleとbodyを更新した場合、データは適切に帰ってくる、また、DB内のデータも更新されている", done => {
     setTimeout(async () => {
@@ -239,7 +239,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
       assert.notStrictEqual(oldTodo, currentTodo);
 
       done();
-    }, 100);
+    }, 10);
   });
   it("titleとcompletedを更新した場合、データは適切に帰ってくる、また、DB内のデータも更新されている", done => {
     setTimeout(async () => {
@@ -278,7 +278,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
       assert.notStrictEqual(oldTodo, currentTodo);
 
       done();
-    }, 100);
+    }, 10);
   });
   it("bodyとcompletedを更新した場合、データは適切に帰ってくる、また、DB内のデータも更新されている", done => {
     setTimeout(async () => {
@@ -317,7 +317,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
       assert.notStrictEqual(oldTodo, currentTodo);
 
       done();
-    }, 100);
+    }, 10);
   });
   it("title、body、completedを更新した場合、データは適切に帰ってくる、また、DB内のデータも更新されている", done => {
     setTimeout(async () => {
@@ -359,6 +359,6 @@ describe("TEST 「PUT /api/todos/:id」", () => {
       assert.notStrictEqual(oldTodo, currentTodo);
 
       done();
-    }, 100);
+    }, 10);
   });
 });

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -80,6 +80,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
       `検索結果: ID${invalidId}に該当するTodoは見つかりませんでした`
     );
   });
+
   it("completedにboolean型以外を送った場合、エラーが返る", async () => {
     const invalidCompletedList = [-1, 2, "0", null, [], {}];
     const id = 3;
@@ -96,6 +97,98 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         response.body.message,
         "completedにはboolean型のみを入力してください"
       );
+    }
+  });
+
+  it("適切にデータを送った場合、idと合致したTodo一件のtitle、body、completed全て、またはいずれかが変更され返ってくる、また配列内にあったidと紐つくコメントは変更されたコメントに上書きされる", async () => {
+    const validId = 3;
+
+    const oldTodos = await getTodos();
+
+    datas = [
+      { title: "title" },
+      { body: "body" },
+      { completed: true },
+      { title: "title", body: "body" },
+      { title: "title", completed: true },
+      { body: "body", completed: true },
+      { title: "title", body: "body", completed: true },
+    ];
+
+    for (let i = 0; i < 5; i++) {
+      const response = await updateTodo(200, validId, datas[i]);
+      const todo = response.body;
+
+      if (datas[i].title && datas[i].body && datas[i].completed) {
+        assert.deepStrictEqual(todo, {
+          id: validId,
+          title: datas[i].title,
+          body: datas[i].body,
+          completed: datas[i].completed,
+          createdAt: todo.createdAt,
+          updatedAt: todo.updatedAt,
+        });
+      } else if (datas[i].title && datas[i].body) {
+        assert.deepStrictEqual(todo, {
+          id: validId,
+          title: datas[i].title,
+          body: datas[i].body,
+          completed: todo.completed,
+          createdAt: todo.createdAt,
+          updatedAt: todo.updatedAt,
+        });
+      } else if (datas[i].title && datas[i].completed) {
+        assert.deepStrictEqual(todo, {
+          id: validId,
+          title: datas[i].title,
+          body: todo.body,
+          completed: datas[i].completed,
+          createdAt: todo.createdAt,
+          updatedAt: todo.updatedAt,
+        });
+      } else if (datas[i].body && datas[i].completed) {
+        assert.deepStrictEqual(todo, {
+          id: validId,
+          title: todo.title,
+          body: datas[i].body,
+          completed: datas[i].completed,
+          createdAt: todo.createdAt,
+          updatedAt: todo.updatedAt,
+        });
+      } else if (datas[i].title) {
+        assert.deepStrictEqual(todo, {
+          id: validId,
+          title: datas[i].title,
+          body: todo.body,
+          completed: todo.completed,
+          createdAt: todo.createdAt,
+          updatedAt: todo.updatedAt,
+        });
+      } else if (datas[i].body) {
+        assert.deepStrictEqual(todo, {
+          id: validId,
+          title: todo.title,
+          body: datas[i].body,
+          completed: todo.completed,
+          createdAt: todo.createdAt,
+          updatedAt: todo.updatedAt,
+        });
+      } else if (datas[i].completed) {
+        assert.deepStrictEqual(todo, {
+          id: validId,
+          title: todo.title,
+          body: datas[i].body,
+          completed: todo.completed,
+          createdAt: todo.createdAt,
+          updatedAt: todo.updatedAt,
+        });
+      }
+
+      assert.strictEqual(todo.updateTodo > todo.createdAt, true);
+
+      const currentTodos = await getTodos();
+
+      assert.notStrictEqual(oldTodos[2], currentTodos[2]);
     }
   });
 });

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -119,7 +119,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         },
       });
 
-      // 配列内にあったidと紐つくTodoは変更されたTodoに上書きされる
+      // DBに格納されていたidと紐つくTodoは変更されたTodoに上書きされる
       assert.notStrictEqual(oldTodo, currentTodo);
 
       done();
@@ -158,7 +158,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         },
       });
 
-      // 配列内にあったidと紐つくTodoは変更されたTodoに上書きされる
+      // DBに格納されていたidと紐つくTodoは変更されたTodoに上書きされる
       assert.notStrictEqual(oldTodo, currentTodo);
       done();
     }, 10);
@@ -196,7 +196,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         },
       });
 
-      // 配列内にあったidと紐つくTodoは変更されたTodoに上書きされる
+      // DBに格納されていたidと紐つくTodoは変更されたTodoに上書きされる
       assert.notStrictEqual(oldTodo, currentTodo);
 
       done();
@@ -235,7 +235,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         },
       });
 
-      // 配列内にあったidと紐つくTodoは変更されたTodoに上書きされる
+      // DBに格納されていたidと紐つくTodoは変更されたTodoに上書きされる
       assert.notStrictEqual(oldTodo, currentTodo);
 
       done();
@@ -274,7 +274,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         },
       });
 
-      // 配列内にあったidと紐つくTodoは変更されたTodoに上書きされる
+      // DBに格納されていたidと紐つくTodoは変更されたTodoに上書きされる
       assert.notStrictEqual(oldTodo, currentTodo);
 
       done();
@@ -313,7 +313,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         },
       });
 
-      // 配列内にあったidと紐つくTodoは変更されたTodoに上書きされる
+      // DBに格納されていたidと紐つくTodoは変更されたTodoに上書きされる
       assert.notStrictEqual(oldTodo, currentTodo);
 
       done();
@@ -339,7 +339,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
 
       assert.deepStrictEqual(todo, {
         id: validId,
-        title: todo.title,
+        title: data.title,
         body: data.body,
         completed: data.completed,
         createdAt: todo.createdAt,
@@ -355,7 +355,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         },
       });
 
-      // 配列内にあったidと紐つくTodoは変更されたTodoに上書きされる
+      // DBに格納されていたidと紐つくTodoは変更されたTodoに上書きされる
       assert.notStrictEqual(oldTodo, currentTodo);
 
       done();

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -12,7 +12,7 @@ const chalk = require("chalk");
 const getTodos = async () => {
   const response = await requestHelper({
     method: "get",
-    endPoint: "api/todos",
+    endPoint: "/api/todos",
     statusCode: 200,
   });
   return response;
@@ -21,7 +21,7 @@ const getTodos = async () => {
 const updateTodo = async (code, id, data) => {
   const response = await requestHelper({
     method: "put",
-    endPoint: `api/todos/${id}`,
+    endPoint: `/api/todos/${id}`,
     statusCode: code,
   }).send(data);
   return response;
@@ -77,10 +77,10 @@ describe("TEST 「PUT /api/todos/:id」", () => {
       body: "body",
     };
 
-    const response = await updateTodo(400, id, data);
+    const response = await updateTodo(400, invalidId, data);
     assert.strictEqual(
       response.body.message,
-      `検索結果: ID${invalidId}に該当するTodoは見つかりませんでした`
+      `検索結果: ID:${invalidId}に該当するTodoは見つかりませんでした`
     );
   });
 
@@ -113,13 +113,13 @@ describe("TEST 「PUT /api/todos/:id」", () => {
     });
 
     datas = [
-      { title: "title" },
-      { body: "body" },
+      { title: "update title" },
+      { body: "update body" },
       { completed: true },
-      { title: "title", body: "body" },
-      { title: "title", completed: true },
-      { body: "body", completed: true },
-      { title: "title", body: "body", completed: true },
+      { title: "update title", body: "update body" },
+      { title: "update title", completed: true },
+      { body: "update body", completed: true },
+      { title: "update title", body: "update body", completed: true },
     ];
 
     for (let i = 0; i < 5; i++) {
@@ -184,14 +184,14 @@ describe("TEST 「PUT /api/todos/:id」", () => {
         assert.deepStrictEqual(todo, {
           id: validId,
           title: todo.title,
-          body: datas[i].body,
-          completed: todo.completed,
+          body: todo.body,
+          completed: datas[i].completed,
           createdAt: todo.createdAt,
           updatedAt: todo.updatedAt,
         });
       }
 
-      assert.strictEqual(todo.updateTodo > todo.createdAt, true);
+      assert.strictEqual(todo.updateAt > todo.createdAt, true);
 
       const currentTodo = await index.Todo.findOne({
         where: {

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -7,6 +7,8 @@ const index = require("../../../../db/models/index");
 const DummyTodo = require("../../../../helper/createHelper");
 const requestHelper = require("../../../../helper/requestHelper").request;
 
+const chalk = require("chalk");
+
 const getTodos = async () => {
   const response = await requestHelper({
     method: "get",
@@ -52,6 +54,7 @@ describe("TEST 「PUT /api/todos/:id」", () => {
 
     for (let i = 0; i < 5; i++) {
       const response = await updateTodo(400, invalidIdList[i], data);
+
       assert.strictEqual(
         response.body.message,
         "idに適切でない値が入っています、1以上の数字を入れてください"

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -103,7 +103,11 @@ describe("TEST 「PUT /api/todos/:id」", () => {
   it("適切にデータを送った場合、idと合致したTodo一件のtitle、body、completed全て、またはいずれかが変更され返ってくる、また配列内にあったidと紐つくコメントは変更されたコメントに上書きされる", async () => {
     const validId = 3;
 
-    const oldTodos = await getTodos();
+    const oldTodo = await index.Todo.findOne({
+      where: {
+        id: validId,
+      },
+    });
 
     datas = [
       { title: "title" },
@@ -186,9 +190,13 @@ describe("TEST 「PUT /api/todos/:id」", () => {
 
       assert.strictEqual(todo.updateTodo > todo.createdAt, true);
 
-      const currentTodos = await getTodos();
+      const currentTodo = await index.Todo.findOne({
+        where: {
+          id: validId,
+        },
+      });
 
-      assert.notStrictEqual(oldTodos[2], currentTodos[2]);
+      assert.notStrictEqual(oldTodo, currentTodo);
     }
   });
 });

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -1,11 +1,29 @@
-/* eslint-disable no-unused-vars */
 /* eslint-disable no-undef */
+/* eslint-disable no-unused-vars */
 const assert = require("power-assert");
 
 const index = require("../../../../db/models/index");
 
 const DummyTodo = require("../../../../helper/createHelper");
 const requestHelper = require("../../../../helper/requestHelper").request;
+
+const getTodos = async () => {
+  const response = await requestHelper({
+    method: "get",
+    endPoint: "api/todos",
+    statusCode: 200,
+  });
+  return response;
+};
+
+const updateTodo = async (code, id, data) => {
+  const response = await requestHelper({
+    method: "put",
+    endPoint: `api/todos/${id}`,
+    statusCode: code,
+  }).send(data);
+  return response;
+};
 
 describe("TEST 「PUT /api/todos/:id」", () => {
   before(async () => {
@@ -23,5 +41,31 @@ describe("TEST 「PUT /api/todos/:id」", () => {
   });
   after(async () => {
     await index.Todo.truncate();
+  });
+
+  it("idの引数に不正な値が入っていた場合、エラーが返る", async () => {
+    const invalidIdList = [
+      { id: 0 },
+      { id: -1 },
+      { id: "0" },
+      { id: true },
+      { id: undefined },
+      { id: null },
+      { id: [] },
+      { id: {} },
+    ];
+
+    const data = {
+      title: "title",
+      body: "body",
+    };
+
+    invalidIdList.forEach(async id => {
+      const response = updateTodo(400, data, id);
+      assert.strictEqual(
+        response.body.message,
+        "idに適切でない値が入っています、1以上の数字を入れてください"
+      );
+    });
   });
 });

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -80,4 +80,22 @@ describe("TEST 「PUT /api/todos/:id」", () => {
       `検索結果: ID${invalidId}に該当するTodoは見つかりませんでした`
     );
   });
+  it("completedにboolean型以外を送った場合、エラーが返る", async () => {
+    const invalidCompletedList = [-1, 2, "0", null, [], {}];
+    const id = 3;
+
+    for (let i = 0; i < 5; i++) {
+      const data = {
+        title: "title",
+        body: "body",
+        completed: invalidCompletedList[i],
+      };
+
+      const response = await updateTodo(400, id, data);
+      assert.strictEqual(
+        response.body.message,
+        "completedにはboolean型のみを入力してください"
+      );
+    }
+  });
 });

--- a/test/src/api/app/api.putTodo.test.js
+++ b/test/src/api/app/api.putTodo.test.js
@@ -1,0 +1,27 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-undef */
+const assert = require("power-assert");
+
+const index = require("../../../../db/models/index");
+
+const DummyTodo = require("../../../../helper/createHelper");
+const requestHelper = require("../../../../helper/requestHelper").request;
+
+describe("TEST 「PUT /api/todos/:id」", () => {
+  before(async () => {
+    const promises = [];
+    for (let i = 0; i < 5; i++) {
+      const promise = index.Todo.create(
+        new DummyTodo({
+          title: `title ${i}`,
+          body: `body ${i}`,
+        })
+      );
+      promises.push(promise);
+    }
+    await Promise.all(promises);
+  });
+  after(async () => {
+    await index.Todo.truncate();
+  });
+});


### PR DESCRIPTION
Issue #9 

# 「`適切にデータを送った場合、idと合致したTodo一件のtitle、body、completed全て、またはいずれかが変更され返ってくる、また配列内にあったidと紐つくコメントは変更されたコメントに上書きされる`」テストについて

## 反省: DRYを無視した記述

全ての状況をテストしようとして、かなりの行で同じようなコードを記述しました。

## たまに通らない

現在「`変更されたTodo１件のupdatedAtは更新されている`」テストがたまに通りません

理由
- `create`で作成されたタイミングとほぼ同時に`updateTodo()`で更新されているので、時間に差が出ずらい

解決策案
- `setTimeOut()`を使用してupdateTodo()の実行時間を若干遅らせる

ですが、setTimeOut()を実行するための記述がいまいちわかりません、いくつか試してみましたが実行時にエラーが出ました(updateTodo()をsetTimeOut()で包む等)
このテストをうまく通すための助言をいただけたら幸いです。

テストの結果
<img width="1280" alt="スクリーンショット 2019-06-24 10 54 57" src="https://user-images.githubusercontent.com/46712701/59985810-9a408780-966e-11e9-8507-2d007ca4163b.png">


--- 

お手すきの際に、コードレビュー、添削等していただけたら幸いです