### PR TITLE
Feature/getters.todosの作成

### DIFF
--- a/client/src/store/getters.js
+++ b/client/src/store/getters.js
@@ -1,3 +1,5 @@
 export default {
-  todos() {}
+  todos(state) {
+    return state.todos;
+  }
 };

--- a/client/src/store/store.js
+++ b/client/src/store/store.js
@@ -5,11 +5,13 @@ Vue.use(Vuex);
 
 import mutations from "./mutations";
 import actions from "./actions";
+import getters from "./getters";
 
 export default new Vuex.Store({
   state: {
     todos: []
   },
   mutations,
-  actions
+  actions,
+  getters
 });

--- a/client/tests/unit/store/getters.spec.js
+++ b/client/tests/unit/store/getters.spec.js
@@ -1,0 +1,30 @@
+import getters from "@/store/getters";
+
+const state = {
+  todos: [
+    {
+      id: 1,
+      title: "getters title",
+      body: "getters body",
+      completed: false,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+  ]
+};
+
+describe("TEST getters.js", () => {
+  it("getters.todosはstate.todosを返す", () => {
+    const result = getters.todos(state);
+    expect(result).toEqual([
+      {
+        id: 1,
+        title: "getters title",
+        body: "getters body",
+        completed: false,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ]);
+  });
+});

--- a/client/tests/unit/store/getters.spec.js
+++ b/client/tests/unit/store/getters.spec.js
@@ -1,4 +1,5 @@
 import getters from "@/store/getters";
+import moment from "moment";
 
 const state = {
   todos: [
@@ -7,8 +8,8 @@ const state = {
       title: "getters title",
       body: "getters body",
       completed: false,
-      createdAt: new Date(),
-      updatedAt: new Date()
+      createdAt: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
+      updatedAt: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 ")
     }
   ]
 };
@@ -22,8 +23,8 @@ describe("TEST getters.js", () => {
         title: "getters title",
         body: "getters body",
         completed: false,
-        createdAt: new Date(),
-        updatedAt: new Date()
+        createdAt: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
+        updatedAt: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 ")
       }
     ]);
   });


### PR DESCRIPTION
# getters.todoを使う理由

`state.todos`をvue内で直接参照すると、外部から汚染される可能性があります。
state.todosを参照するときはgettersを使用し、todosの操作はVuex内で完結させることで、汚染を防ぐことができます。

# 行なったこと

## 1 .getters.todosのテスト作成

### state.todos

Todo(ダミーデータ)を含んだ配列です。テスト時にこちらを会得します。

### テスト内容

- `getters.todosはstate.todosを返す`
`toEqual`にstate.todoと同じ配列を用意し、`getters.todo`が`state.todos`を返せているかテストします。

## 2. getters.todoの作成
単純に`state.todos`をリターンします。

# テスト結果
<img width="488" alt="スクリーンショット 2019-07-23 19 40 20" src="https://user-images.githubusercontent.com/46712701/61705916-c50f2000-ad81-11e9-9d77-3b45aac78f33.png">