### PR TITLE
Feature/【CREATE】mutations.addTodoの作成

### DIFF
--- a/client/src/store/mutations.js
+++ b/client/src/store/mutations.js
@@ -1,5 +1,8 @@
 export default {
   setTodos(state, todos) {
     state.todos = todos;
+  },
+  addTodo(state, todo) {
+    state.todos.push(todo)
   }
 };

--- a/client/src/store/mutations.js
+++ b/client/src/store/mutations.js
@@ -3,6 +3,6 @@ export default {
     state.todos = todos;
   },
   addTodo(state, todo) {
-    state.todos.push(todo)
+    state.todos.push(todo);
   }
 };

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -34,4 +34,21 @@ describe("TEST mutations.js", () => {
 
     expect(state.todos).toEqual(todos);
   });
+  it("addTodoは、渡されたTodoデータをstate.todosの末尾に追加する", () => {
+    const newTodo = {
+      title: "new title",
+      body: "new body"
+    };
+
+    mutations.addTodo(state, newTodo);
+
+    expect(state.todos[5]).toEqual({
+      id: 6,
+      ttile: newTodo.title,
+      body: newTodo.body,
+      completed: false,
+      createdAt: state.todos[5],
+      updatedAt: state.todos[5]
+    });
+  });
 });

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -43,6 +43,5 @@ describe("TEST mutations.js", () => {
     mutations.addTodo(state, newTodo);
 
     expect(state.todos[5]).toEqual(newTodo);
-
-  })
+  });
 });

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -48,7 +48,8 @@ describe("TEST mutations.js", () => {
       body: newTodo.body,
       completed: false,
       createdAt: state.todos[5],
-      updatedAt: state.todos[5]
+      updatedAt: state.todos[5],
     });
-  });
+
+  })
 });

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -35,21 +35,14 @@ describe("TEST mutations.js", () => {
     expect(state.todos).toEqual(todos);
   });
   it("addTodoは、渡されたTodoデータをstate.todosの末尾に追加する", () => {
-    const newTodo = {
+    const newTodo = new Todo({
       title: "new title",
       body: "new body"
-    };
+    });
 
     mutations.addTodo(state, newTodo);
 
-    expect(state.todos[5]).toEqual({
-      id: 6,
-      ttile: newTodo.title,
-      body: newTodo.body,
-      completed: false,
-      createdAt: state.todos[5],
-      updatedAt: state.todos[5],
-    });
+    expect(state.todos[5]).toEqual(newTodo);
 
   })
 });


### PR DESCRIPTION
# 行なったこと

## 1.mutations.addTodoのテスト作成

### テスト内容
- `addTodoは、渡されたTodoデータをstate.todosの末尾に追加する`
`actions`から渡されたTodoデータが、`state.todos`の末尾に追加されているか確認するためのテストです。

## 2. mutations.addTodoの作成
渡された`todo`を`push`メソッドを使用して`state.todos`の末尾に追加します

# テスト結果
<img width="485" alt="スクリーンショット 2019-07-24 9 22 25" src="https://user-images.githubusercontent.com/46712701/61755902-93836c80-adf4-11e9-9c9c-1cf13ea6dd0c.png">

