### PR TITLE
Feature/actions.postTodoの作成

### DIFF
--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -16,10 +16,12 @@ export default {
     try {
       const res = await axios.post(API_URL, {
         title: title,
-        body: body
+        body: body,
+        completed: false
       });
+      console.log(res)
       const todoData = res.data;
-      commit("addTodos", todoData);
+      commit("addTodo", todoData);
     } catch (error) {
       throw new Error("APIエラーが発生しました");
     }

--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -12,14 +12,13 @@ export default {
       throw new Error("APIエラーが発生しました");
     }
   },
-  async postTodo({ commit }, { title, body }) {
+  async postTodo({ commit }, { newTitle, newBody }) {
     try {
       const res = await axios.post(API_URL, {
-        title: title,
-        body: body,
+        title: newTitle,
+        body: newBody,
         completed: false
       });
-      console.log(res)
       const todoData = res.data;
       commit("addTodo", todoData);
     } catch (error) {

--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -12,5 +12,16 @@ export default {
       throw new Error("APIエラーが発生しました");
     }
   },
-  async postTodo({ commit }, { title, body }) {}
+  async postTodo({ commit }, { title, body }) {
+    try {
+      const res = await axios.post(API_URL, {
+        title: title,
+        body: body
+      });
+      const todoData = res.data;
+      commit("addTodos", todoData);
+    } catch (error) {
+      throw new Error("APIエラーが発生しました");
+    }
+  }
 };

--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -11,5 +11,6 @@ export default {
     } catch (error) {
       throw new Error("APIエラーが発生しました");
     }
-  }
+  },
+  async postTodo({ commit }, { title, body }) {}
 };

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -12,6 +12,18 @@ jest.mock("axios", () => ({
       url = _url;
       resolve({ data: true });
     });
+  },
+  post: (_url, { title, body }) => {
+    return new Promise(resolve => {
+      if (mockError) {
+        throw Error();
+      }
+      url = _url;
+      resolve({
+        title,
+        body
+      });
+    });
   }
 }));
 

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -28,6 +28,9 @@ jest.mock("axios", () => ({
 }));
 
 describe("TEST acitons.js", () => {
+  beforeEach(() => {
+    mockError =false
+  })
   it("actions.fetchTodosは、DBからTodoデータを引き出し、mutations.setTodosに渡す", async () => {
     const commit = jest.fn();
     await actions.fetchTodos({ commit });

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -27,7 +27,7 @@ jest.mock("axios", () => ({
 }));
 
 describe("TEST acitons.js", () => {
-  beforeEach(() => {
+  afterEach(() => {
     mockError = false;
   });
   it("actions.fetchTodosは、DBからTodoデータを引き出し、mutations.setTodosに渡す", async () => {

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -1,6 +1,7 @@
 import actions from "@/store/actions";
 
 let url = "";
+let body = {};
 let mockError = false;
 
 jest.mock("axios", () => ({
@@ -13,24 +14,22 @@ jest.mock("axios", () => ({
       resolve({ data: true });
     });
   },
-  post: (_url, { title, body }) => {
+  post: (_url, _body) => {
     return new Promise(resolve => {
       if (mockError) {
         throw Error();
       }
       url = _url;
-      resolve({
-        title,
-        body
-      });
+      body = _body;
+      resolve({ data: true });
     });
   }
 }));
 
 describe("TEST acitons.js", () => {
   beforeEach(() => {
-    mockError =false
-  })
+    mockError = false;
+  });
   it("actions.fetchTodosは、DBからTodoデータを引き出し、mutations.setTodosに渡す", async () => {
     const commit = jest.fn();
     await actions.fetchTodos({ commit });
@@ -47,16 +46,14 @@ describe("TEST acitons.js", () => {
   });
   it("actions.postTodoは、DBに新たなTodo１件を作成し、作成したTodoをmutations.addTodoに渡す", async () => {
     const commit = jest.fn();
-    const title = "new Title";
-    const body = "new Body";
+    const newTitle = "new Title";
+    const newBody = "new Body";
 
-    await actions.postTodo({ commit }, { title, body });
+    await actions.postTodo({ commit }, { newTitle, newBody });
 
     expect(url).toBe("http://localhost:8040/api/todos");
-    expect(commit).toHaveBeenCalledWith("addTodo", {
-      title,
-      body
-    });
+    expect(body).toEqual({ title: newTitle, body: newBody, completed: false });
+    expect(commit).toHaveBeenCalledWith("addTodo", true);
   });
   it("actions.postTodoのエラー発生時テスト", async () => {
     mockError = true;

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -42,5 +42,24 @@ describe("TEST acitons.js", () => {
       "APIエラーが発生しました"
     );
   });
-  it("actions.postTodoは、DBに新たなTodo１件を作成し、作成したTodoをmutations.addTodoに渡す", async () => {});
+  it("actions.postTodoは、DBに新たなTodo１件を作成し、作成したTodoをmutations.addTodoに渡す", async () => {
+    const commit = jest.fn();
+    const title = "new Title";
+    const body = "new Body";
+
+    await actions.postTodo({ commit }, { title, body });
+
+    expect(url).toBe("http://localhost:8040/api/todos");
+    expect(commit).toHaveBeenCalledWith("addTodo", {
+      title,
+      body
+    });
+  });
+  it("actions.postTodoのエラー発生時テスト", async () => {
+    mockError = true;
+
+    await expect(actions.postTodo({ commit: jest.fn() }, {})).rejects.toThrow(
+      "APIエラーが発生しました"
+    );
+  });
 });

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -30,4 +30,5 @@ describe("TEST acitons.js", () => {
       "APIエラーが発生しました"
     );
   });
+  it("actions.postTodoは、DBに新たなTodo１件を作成し、作成したTodoをmutations.addTodoに渡す", async () => {});
 });


### PR DESCRIPTION
# 行なったこと

## 1. actions.postTodoのテスト作成

### モック関数の追加(`post`)
今回はpostリクエストを使用するので、モック関数を追加しました。
第二引数からactions.postTodoで渡されるデータを得れるようにして、`body`に渡します(テスト時に使用)

### mockErrorを常に`false`にしておく
mockErrorはエラーテスト時のみ`true`にしておきたいので、`afterEach`を使用して各テスト後、mockErrorに`false`を渡すようにしました

### テスト内容

- `actions.postTodoは、DBに新たなTodo１件を作成し、作成したTodoをmutations.addTodoに渡す`
postTodoが`post`リクエストを実行した場合、URL、渡したデータなどに問題がないかチェックをします。

- `actions.postTodoのエラー発生時テスト`
postTodoが`post`リクエストに失敗した場合、適切なエラーを返すかチェックをします

## 2. actions.postTodoの作成
メソッド内で`axios.post()`を実行、指定したAPIアドレスに`title`、`body`、またタスク確認用の`completed`を渡します。基本的にtodo作成時点でタスクは終了してないと思われるので、completedには`false`を入れています。

# テスト結果
<img width="485" alt="スクリーンショット 2019-07-24 10 41 37" src="https://user-images.githubusercontent.com/46712701/61758816-45289a80-ae01-11e9-8254-6b92631eac94.png">
