### PR TITLE
Feature/インプットフォームからデータを送信した時、Todoを一件新規に製作し、表示する

### DIFF
--- a/client/src/components/Input.vue
+++ b/client/src/components/Input.vue
@@ -15,10 +15,10 @@
         </v-layout>
         <v-layout justify-center>
           <v-flex xs12 sm4 md5>
-            <v-text-field label="タイトルを入力してください"  :rules="inputRule" v-model="title"></v-text-field>
+            <v-text-field label="タイトルを入力してください" validate-on-blur :rules="inputRule" v-model="title"></v-text-field>
           </v-flex>
           <v-flex xs12 sm4 md5>
-            <v-text-field label="内容を入力してください" :rules="inputRule" v-model="body"></v-text-field>
+            <v-text-field label="内容を入力してください" validate-on-blur :rules="inputRule" v-model="body"></v-text-field>
           </v-flex>
           <v-flex xs12 sm4 md2>
             <v-btn outline align-center color="primary" :disabled="!title || !body" @click="postTodoButton()">送信</v-btn>

--- a/client/src/components/Input.vue
+++ b/client/src/components/Input.vue
@@ -18,10 +18,10 @@
             <v-text-field label="タイトルを入力してください" v-model="title"></v-text-field>
           </v-flex>
           <v-flex xs12 sm4 md5>
-            <v-text-field label="内容を入力してください" v-model="text"></v-text-field>
+            <v-text-field label="内容を入力してください" v-model="body"></v-text-field>
           </v-flex>
           <v-flex xs12 sm4 md2>
-            <v-btn outline align-center color="primary" dark @click="dummy = !dummy">送信</v-btn>
+            <v-btn outline align-center color="primary" dark @click="postTodoButton()">送信</v-btn>
           </v-flex>
         </v-layout>
       </v-container>
@@ -30,15 +30,23 @@
 </template>
 
 <script>
+import { mapActions } from "vuex";
 export default {
   data() {
     return {
       title: "",
-      text: "",
+      body: "",
       isError: false,
-      errorMsg: "",
-      dummy: false
+      errorMsg: ""
     };
   },
+  methods: {
+    ...mapActions(["postTodo"]),
+    postTodoButton() {
+      this.postTodo({ newTitle: this.title, newBody: this.body });
+      this.title = "";
+      this.body = "";
+    }
+  }
 };
 </script>

--- a/client/src/components/Input.vue
+++ b/client/src/components/Input.vue
@@ -21,7 +21,7 @@
             <v-text-field label="内容を入力してください" :rules="inputRule" v-model="body"></v-text-field>
           </v-flex>
           <v-flex xs12 sm4 md2>
-            <v-btn outline align-center color="primary" dark @click="postTodoButton()">送信</v-btn>
+            <v-btn outline align-center color="primary" :disabled="!title || !body" @click="postTodoButton()">送信</v-btn>
           </v-flex>
         </v-layout>
       </v-container>

--- a/client/src/components/Input.vue
+++ b/client/src/components/Input.vue
@@ -21,7 +21,13 @@
             <v-text-field label="内容を入力してください" validate-on-blur :rules="inputRule" v-model="body"></v-text-field>
           </v-flex>
           <v-flex xs12 sm4 md2>
-            <v-btn outline align-center color="primary" :disabled="!title || !body" @click="postTodoButton()">送信</v-btn>
+            <v-btn
+              outline
+              align-center
+              color="primary"
+              :disabled="!title || !body"
+              @click="postTodoButton()"
+            >送信</v-btn>
           </v-flex>
         </v-layout>
       </v-container>

--- a/client/src/components/Input.vue
+++ b/client/src/components/Input.vue
@@ -15,10 +15,10 @@
         </v-layout>
         <v-layout justify-center>
           <v-flex xs12 sm4 md5>
-            <v-text-field label="タイトルを入力してください" v-model="title"></v-text-field>
+            <v-text-field label="タイトルを入力してください"  :rules="inputRule" v-model="title"></v-text-field>
           </v-flex>
           <v-flex xs12 sm4 md5>
-            <v-text-field label="内容を入力してください" v-model="body"></v-text-field>
+            <v-text-field label="内容を入力してください" :rules="inputRule" v-model="body"></v-text-field>
           </v-flex>
           <v-flex xs12 sm4 md2>
             <v-btn outline align-center color="primary" dark @click="postTodoButton()">送信</v-btn>
@@ -39,6 +39,11 @@ export default {
       isError: false,
       errorMsg: ""
     };
+  },
+  computed: {
+    inputRule() {
+      return [v => !!v || "必ず入力してください"];
+    }
   },
   methods: {
     ...mapActions(["postTodo"]),


### PR DESCRIPTION
# 行なったこと

## Input.vue

### postTodoButtonの作成
`タイトル(title)`、`内容(body)`項目を入力し、送信ボタンを押すと、入力したデータが`postTodo`に渡されるようにしました。その後、title、bodyに空文字列を代入します。

### 項目が空白の場合、送信ボタンを押せないようにした
`<v-btn>`に`:disabled`オプションを追加して、`title`、`body`が空の場合はボタンを押すことができないようにしました。

### 各項目が空白の場合、エラーを表示するようにした
`<v-text-field>`に`:rules`オプションを追加し`title`、また`body`が空の場合、インプットフォームにエラーを表示するようにしました。

#### 問題:送信後、エラーが表示される
送信後、擬似リロードとしてデータに空文字列を渡すことで、インプットフォームがエラーを表示するようにしました。`:rules`は、何らかの動きがあった場合常に実行されるようです
![postTodo no-blur](https://user-images.githubusercontent.com/46712701/61761426-9a68aa00-ae09-11e9-8a7e-24517375213f.gif)

#### 解決: `validate-on-blur`オプションを追加する
`<v-text-field>`に`validate-on-blur`オプションを追加します。これでインプットフォームからフォーカスが外れた場合にのみエラーが表示されるようになりました。

参考: [Vuetify:Inpus - API](https://vuetifyjs.com/en/components/inputs#api)

# Todoアプリ
![postTodo-blur](https://user-images.githubusercontent.com/46712701/61761442-a81e2f80-ae09-11e9-838a-f00633e4d63e.gif)

# DB内
<img width="1162" alt="スクリーンショット 2019-07-24 11 57 15" src="https://user-images.githubusercontent.com/46712701/61761625-35fa1a80-ae0a-11e9-89b8-3f07654a0af0.png">
