### PR TITLE
Update/Todoカードをクリックすると、TodoDialogが開く

### DIFF
--- a/client/src/components/Todo/Todo.vue
+++ b/client/src/components/Todo/Todo.vue
@@ -1,20 +1,16 @@
 <template>
   <div>
     <v-container xs12 sm6 md3>
-      <v-card hover class="card" width="200px" @click="dummy = !dummy">
+      <v-card hover class="card" width="200px" @click="showTodoDialog()">
         <v-layout justify-end class="closeBox">
-          <v-btn @click.stop="" class="closeBtn" fab small depressed flat>
+          <v-btn @click.stop class="closeBtn" fab small depressed flat>
             <v-icon>far fa-times-circle</v-icon>
           </v-btn>
         </v-layout>
 
         <v-layout align-center justify-center class="card-inside">
           <v-flex xs2 grow>
-            <v-checkbox
-              class="checkbox"
-              :value="todo.completed"
-              @click.stop=""
-            ></v-checkbox>
+            <v-checkbox class="checkbox" :value="todo.completed" @click.stop></v-checkbox>
           </v-flex>
           <v-flex>
             <v-list-tile-action>
@@ -53,6 +49,12 @@ export default {
   components: {
     appTodoDialog: TodoDialog,
     appDeleteDialog: DeleteDialog
+  },
+  methods: {
+    showTodoDialog() {
+      this.$refs.todoDialog.open();
+      this.selectedTodo = this.todo;
+    }
   }
 };
 </script>

--- a/client/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/client/src/components/Todo/dialogs/DeleteDialog.vue
@@ -30,5 +30,10 @@ export default {
       dummy: false
     };
   },
+  methods: {
+    open() {
+      this.isOpen = true
+    }
+  },
 };
 </script>

--- a/client/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/client/src/components/Todo/dialogs/DeleteDialog.vue
@@ -29,11 +29,6 @@ export default {
       isOpen: false,
       dummy: false
     };
-  },
-  methods: {
-    open() {
-      this.isOpen = true
-    }
-  },
+  }
 };
 </script>

--- a/client/src/components/Todo/dialogs/TodoDialog.vue
+++ b/client/src/components/Todo/dialogs/TodoDialog.vue
@@ -9,11 +9,11 @@
       </v-card-actions>
 
       <v-divider></v-divider>
-      <v-card-text v-if="!isUpdate" class="modal-todo-text">{{ todo.text }}</v-card-text>
+      <v-card-text v-if="!isUpdate" class="modal-todo-text">{{ todo.body }}</v-card-text>
       <v-card-actions v-if="isUpdate">
         <v-text-field v-model="text" label="text" :rules="inputRule" required></v-text-field>
       </v-card-actions>
-      <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
+      <v-card-text class="modal-todo-date">作成日: {{ createdAt }}<br>更新日: {{ updatedAt }} </v-card-text>
       <v-spacer></v-spacer>
       <v-card-actions>
         <v-checkbox
@@ -39,13 +39,15 @@
 </template>
 
 <script>
+import moment from "moment"
 export default {
   props: {
     todo: {
       id: Number,
       title: String,
-      text: String,
-      date: String,
+      body: String,
+      cleatedAt: String,
+      updatedAt: String,
       completed: Boolean
     }
   },
@@ -56,12 +58,19 @@ export default {
       text: "",
       isOpen: false,
       isUpdate: false,
-      dummy: false
+      dummy: false,
+      createdAt: moment(this.cleatedAt).format("YYYY年 MM月 Do(ddd), kk時mm分 "),
+      updatedAt: moment(this.updatedAt).format("YYYY年 MM月 Do(ddd), kk時mm分 ")
     };
   },
   computed: {
     inputRule() {
       return [v => !!v || "必ず入力してください"];
+    }
+  },
+  methods: {
+    open() {
+      this.isOpen = true;
     }
   },
 };


### PR DESCRIPTION
# 行なったこと

## TodoDialog.vue

- propsの型指定
間違っていたので修正

- open()の作成
`Todo.vue`から`$ref`で操作するために作成、TodoDialogを開く機能

- 表示項目の追加
`updatedAt`の表示

## Todo.vue

- propsの型指定
間違っていたので修正

- showTodoDialogの作成
クリックしたTodoカードの詳細を表示する

