### PR TITLE
Feature/【UPDATE】mutations.updateTodoの作成

### DIFF
--- a/client/src/store/mutations.js
+++ b/client/src/store/mutations.js
@@ -5,5 +5,9 @@ export default {
   addTodo(state, todo) {
     state.todos.push(todo);
   },
-  updateTodo(state, editData) {}
+  updateTodo(state, editData) {
+    const updateIndex = state.todos.findIndex(todo => editData.id === todo.id);
+    state.todos[updateIndex].title = editData.title;
+    state.todos[updateIndex].body = editData.body;
+  }
 };

--- a/client/src/store/mutations.js
+++ b/client/src/store/mutations.js
@@ -4,5 +4,6 @@ export default {
   },
   addTodo(state, todo) {
     state.todos.push(todo);
-  }
+  },
+  updateTodo(state, editData) {}
 };

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -52,7 +52,6 @@ describe("TEST mutations.js", () => {
     };
 
     mutations.updateTodo(state, editData);
-    
     expect(state.todos[0].id).toBe(editData.id);
     expect(state.todos[0].title).toBe(editData.title);
     expect(state.todos[0].body).toBe(editData.body);

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -52,9 +52,11 @@ describe("TEST mutations.js", () => {
     };
 
     mutations.updateTodo(state, editData);
-    expect(state.todos[0].id).toBe(editData.id);
-    expect(state.todos[0].title).toBe(editData.title);
-    expect(state.todos[0].body).toBe(editData.body);
-    
-  })
+
+    expect(state.todos[0]).toMatchObject(
+      { id: editData.id },
+      { title: editData.title },
+      { body: editData.body }
+    );
+  });
 });

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -44,4 +44,18 @@ describe("TEST mutations.js", () => {
 
     expect(state.todos[5]).toEqual(newTodo);
   });
+  it("updateTodoは、指定したIDの値と合致するTodo一件のtitleとbodyを変更する", () => {
+    const editData = {
+      id: 1,
+      title: "update title",
+      body: "update text"
+    };
+
+    mutations.updateTodo(state, editData);
+    
+    expect(state.todos[0].id).toBe(editData.id);
+    expect(state.todos[0].title).toBe(editData.title);
+    expect(state.todos[0].body).toBe(editData.body);
+    
+  })
 });


### PR DESCRIPTION
# 行なったこと

## 1. mutations.updateTodoの作成

### テスト内容

- `updateTodoは、指定したIDの値と合致するTodo一件のtitleとbodyを変更する`
`actions`から渡されたデータを元に、合致したTodo一件のデータが適切に変更されているかチェックします

## 2. mutations.updateTodoの作成
渡されるデータ
- id
この値を元に、Todo一件を検索、会得します。
- title
会得したTodoのtitleを変更します
- body
会得したTodoのbodyを変更します。

# テスト結果
<img width="487" alt="スクリーンショット 2019-07-24 14 03 28" src="https://user-images.githubusercontent.com/46712701/61766450-da388d00-ae1b-11e9-910f-dd9c61c50327.png">
