### PR TITLE
Feature/【UPDATE】actions.putTodoの作成

### DIFF
--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -25,5 +25,14 @@ export default {
       throw new Error("APIエラーが発生しました");
     }
   },
-  async putTodo({ commit }, editData) {}
+  async putTodo({ commit }, editData) {
+    try {
+      const res = await axios.put(API_URL + `/${editData.id}`, {
+        title: editData.editTitle,
+        body: editData.editBody
+      });
+      const todoData = res.data;
+      commit("updateTodo", todoData);
+    } catch (error) {}
+  }
 };

--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -28,8 +28,8 @@ export default {
   async putTodo({ commit }, editData) {
     try {
       const res = await axios.put(API_URL + `/${editData.id}`, {
-        title: editData.editTitle,
-        body: editData.editBody
+        title: editData.title,
+        body: editData.body
       });
       const todoData = res.data;
       commit("updateTodo", todoData);

--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -24,5 +24,6 @@ export default {
     } catch (error) {
       throw new Error("APIエラーが発生しました");
     }
-  }
+  },
+  async putTodo({ commit }, editData) {}
 };

--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -33,6 +33,8 @@ export default {
       });
       const todoData = res.data;
       commit("updateTodo", todoData);
-    } catch (error) {}
+    } catch (error) {
+      throw new Error("APIエラーが発生しました");
+    }
   }
 };

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -88,8 +88,8 @@ describe("TEST acitons.js", () => {
   it("actions.putTodoのエラー発生時テスト", async () => {
     mockError = true;
 
-    await expect(actions.putTodo({ commit: jest.fn() }, {})).toThrow(
-      "APIエラーが発生しました。"
+    await expect(actions.putTodo({ commit: jest.fn() }, {})).rejects.toThrow(
+      "APIエラーが発生しました"
     );
   });
 });

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -89,4 +89,11 @@ describe("TEST acitons.js", () => {
       { body: editData.editBody }
     );
   });
+  it("actions.putTodoのエラー発生時テスト", async () => {
+    mockError = true;
+
+    await expect(actions.putTodo({ commit: jest.fn() }, {})).toThrow(
+      "APIエラーが発生しました。"
+    );
+  });
 });

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -31,6 +31,7 @@ jest.mock("axios", () => ({
       }
       url = _url;
       body = _body;
+      console.log(_body);
       resolve({ data: true });
     });
   }
@@ -76,18 +77,14 @@ describe("TEST acitons.js", () => {
     const commit = jest.fn();
     const editData = {
       id: 1,
-      editTitle: "update Title",
-      editBody: "update Body"
+      title: "update Title",
+      body: "update Body"
     };
 
     await actions.putTodo({ commit }, editData);
 
-    expect(url).toBe("http://localhost:8040/api/todos/1");
-    expect(body).toMatchObject(
-      { id: editData.id },
-      { title: editData.editTitle },
-      { body: editData.editBody }
-    );
+    expect(url).toBe(`http://localhost:8040/api/todos/${editData.id}`);
+    expect(body).toEqual({ title: editData.title, body: editData.body });
   });
   it("actions.putTodoのエラー発生時テスト", async () => {
     mockError = true;

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -72,4 +72,21 @@ describe("TEST acitons.js", () => {
       "APIエラーが発生しました"
     );
   });
+  it("actions.putTodoは、渡されたidと合致するTodo一件のtitleとbodyを変更し、変更したTodoをmutations.updateTodoに渡す", async () => {
+    const commit = jest.fn();
+    const editData = {
+      id: 1,
+      editTitle: "update Title",
+      editBody: "update Body"
+    };
+
+    await actions.putTodo({ commit }, editData);
+
+    expect(url).toBe("http://localhost:8040/api/todos/1");
+    expect(body).toMatchObject(
+      { id: editData.id },
+      { title: editData.editTitle },
+      { body: editData.editBody }
+    );
+  });
 });

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -23,6 +23,16 @@ jest.mock("axios", () => ({
       body = _body;
       resolve({ data: true });
     });
+  },
+  put: (_url, _body) => {
+    return new Promise(resolve => {
+      if (mockError) {
+        throw Error();
+      }
+      url = _url;
+      body = _body;
+      resolve({ data: true });
+    });
   }
 }));
 

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -84,6 +84,7 @@ describe("TEST acitons.js", () => {
 
     expect(url).toBe(`http://localhost:8040/api/todos/${editData.id}`);
     expect(body).toEqual({ title: editData.title, body: editData.body });
+    expect(commit).toHaveBeenCalledWith("updateTodo", true);
   });
   it("actions.putTodoのエラー発生時テスト", async () => {
     mockError = true;

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -31,7 +31,6 @@ jest.mock("axios", () => ({
       }
       url = _url;
       body = _body;
-      console.log(_body);
       resolve({ data: true });
     });
   }


### PR DESCRIPTION
# 行なったこと
 ## 1. actions.putTodoのテスト作成

### モック関数の追加(`put`)
第二引数からactions.postTodoで渡されるデータを得れるようにして、`body`に渡します(テスト時に使用)

### テスト内容

- `actions.putTodoは、渡されたidと合致するTodo一件のtitleとbodyを変更し、変更したTodoをmutations.updateTodoに渡す`
putTodoが`put`リクエストを実行したあと、URL、渡したデータ等に間違いがないかチェックします

- `actions.putTodoのエラー発生時テスト`
putTodoが`put`リクエストに失敗した場合、適切なエラーを返すかチェックします

## 2. actions.putTodoの作成

`put`リクエストを実行、指定したAPIアドレスの末尾に`id`を加え、特定のTodoを会得します。
会得したTodoの`title`、`body`を引数で渡された新たなデータに変更し、`mutations.updateTodo`に渡します。

# テスト結果
<img width="487" alt="スクリーンショット 2019-07-24 15 12 19" src="https://user-images.githubusercontent.com/46712701/61769511-79ae4d80-ae25-11e9-8f87-6fb3b2fa7500.png">
