### PR TITLE
Update/編集ボタンを押すと、TodoDialogが編集画面に切り替わる

### DIFF
--- a/client/src/components/Todo/dialogs/TodoDialog.vue
+++ b/client/src/components/Todo/dialogs/TodoDialog.vue
@@ -11,7 +11,7 @@
       <v-divider></v-divider>
       <v-card-text v-if="!isUpdate" class="modal-todo-text">{{ todo.body }}</v-card-text>
       <v-card-actions v-if="isUpdate">
-        <v-text-field v-model="text" label="text" :rules="inputRule" required></v-text-field>
+        <v-text-field v-model="body" label="内容" :rules="inputRule" required></v-text-field>
       </v-card-actions>
       <v-card-text class="modal-todo-date">
         作成日: {{ createdAt }}
@@ -29,7 +29,7 @@
             color="info"
             outline
             @click="dummy = !dummy"
-            :disabled="!title || !text"
+            :disabled="!title || !body"
           >変更</v-btn>
         </v-layout>
       </v-card-actions>
@@ -54,7 +54,7 @@ export default {
     return {
       copiedTodo: this.todo,
       title: "",
-      text: "",
+      body: "",
       isOpen: false,
       isUpdate: false,
       dummy: false,
@@ -75,6 +75,8 @@ export default {
     },
     editorOpen() {
       this.isUpdate = true;
+      this.title = this.todo.title;
+      this.body = this.todo.body;
     },
     editorClose() {
       this.isUpdate = false;

--- a/client/src/components/Todo/dialogs/TodoDialog.vue
+++ b/client/src/components/Todo/dialogs/TodoDialog.vue
@@ -22,8 +22,8 @@
       <v-card-actions>
         <v-checkbox v-if="!isUpdate" class="modal-checkbox" :value="todo.completed" @click.stop></v-checkbox>
         <v-layout row wrap justify-end>
-          <v-btn v-if="!isUpdate" color="success" @click="dummy = !dummy" outline>編集</v-btn>
-          <v-btn v-if="isUpdate" color="error" @click="dummy = !dummy">キャンセル</v-btn>
+          <v-btn v-if="!isUpdate" color="success" @click="editorOpen()" outline>編集</v-btn>
+          <v-btn v-if="isUpdate" color="error" @click="editorClose()">キャンセル</v-btn>
           <v-btn
             v-if="isUpdate"
             color="info"
@@ -72,6 +72,12 @@ export default {
   methods: {
     open() {
       this.isOpen = true;
+    },
+    editorOpen() {
+      this.isUpdate = true;
+    },
+    editorClose() {
+      this.isUpdate = false;
     }
   }
 };


### PR DESCRIPTION
# 行なったこと

## TodoDialog.vue

- editorOpenの作成
編集ボタンを押すことで、`isUpdate`がtrueになり、`isUpdate`を引数に設定していた要素の表示/非表示を行い、TodoDialogを編集画面に切り替えます。
データの`title`、`body`にはtodoのデータを渡して、インプットフォームに表示します。

- editorCloseの作成
キャンセルボタンを押すことで、`isUpdate`がfalseになり、`isUpdate`を引数に設定していた要素の表示/非表示を行い、TodoDialogを詳細画面に切り替えます。