### PR TITLE
Feature/【UPDATE】編集画面からデータを送信した時、編集したTodo一件のデータを変更し、表示する

### DIFF
--- a/client/src/components/Todo/dialogs/TodoDialog.vue
+++ b/client/src/components/Todo/dialogs/TodoDialog.vue
@@ -28,7 +28,7 @@
             v-if="isUpdate"
             color="info"
             outline
-            @click="dummy = !dummy"
+            @click="putTodoButton()"
             :disabled="!title || !body"
           >変更</v-btn>
         </v-layout>
@@ -58,7 +58,6 @@ export default {
       body: "",
       isOpen: false,
       isUpdate: false,
-      dummy: false,
       createdAt: moment(this.cleatedAt).format(
         "YYYY年 MM月 DD日(ddd), kk時mm分 "
       ),

--- a/client/src/components/Todo/dialogs/TodoDialog.vue
+++ b/client/src/components/Todo/dialogs/TodoDialog.vue
@@ -53,20 +53,21 @@ export default {
   },
   data() {
     return {
-      copiedTodo: this.todo,
       title: "",
       body: "",
       isOpen: false,
       isUpdate: false,
-      createdAt: moment(this.cleatedAt).format(
-        "YYYY年 MM月 DD日(ddd), kk時mm分 "
-      ),
-      updatedAt: moment(this.updatedAt).format("YYYY年 MM月 DD日(ddd), kk時mm分 ")
     };
   },
   computed: {
     inputRule() {
       return [v => !!v || "必ず入力してください"];
+    },
+    createdAt() {
+      return moment(this.todo.createdAt).format("YYYY年 MM月 DD日(ddd), kk時mm分 ");
+    },
+    updatedAt() {
+      return moment(this.todo.updatedAt).format("YYYY年 MM月 DD日(ddd), kk時mm分 ");
     }
   },
   methods: {
@@ -84,14 +85,14 @@ export default {
     },
     putTodoButton() {
       const editData = {
-        id: this.id,
+        id: this.todo.id,
         title: this.title,
         body: this.body
       };
       this.putTodo(editData);
       this.title = "";
       this.body = "";
-      this.editorClose()
+      this.editorClose();
     }
   }
 };

--- a/client/src/components/Todo/dialogs/TodoDialog.vue
+++ b/client/src/components/Todo/dialogs/TodoDialog.vue
@@ -39,6 +39,7 @@
 
 <script>
 import moment from "moment";
+import { mapActions } from "vuex";
 export default {
   props: {
     todo: {
@@ -70,6 +71,7 @@ export default {
     }
   },
   methods: {
+    ...mapActions(["putTodo"]),
     open() {
       this.isOpen = true;
     },
@@ -80,6 +82,17 @@ export default {
     },
     editorClose() {
       this.isUpdate = false;
+    },
+    putTodoButton() {
+      const editData = {
+        id: this.id,
+        title: this.title,
+        body: this.body
+      };
+      this.putTodo(editData);
+      this.title = "";
+      this.body = "";
+      this.editorClose()
     }
   }
 };

--- a/client/src/components/Todo/dialogs/TodoDialog.vue
+++ b/client/src/components/Todo/dialogs/TodoDialog.vue
@@ -59,9 +59,9 @@ export default {
       isUpdate: false,
       dummy: false,
       createdAt: moment(this.cleatedAt).format(
-        "YYYY年 MM月 Do(ddd), kk時mm分 "
+        "YYYY年 MM月 DD日(ddd), kk時mm分 "
       ),
-      updatedAt: moment(this.updatedAt).format("YYYY年 MM月 Do(ddd), kk時mm分 ")
+      updatedAt: moment(this.updatedAt).format("YYYY年 MM月 DD日(ddd), kk時mm分 ")
     };
   },
   computed: {

--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -27,6 +27,7 @@ export default {
   },
   async putTodo({ commit }, editData) {
     try {
+      console.log(editData)
       const res = await axios.put(API_URL + `/${editData.id}`, {
         title: editData.title,
         body: editData.body

--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -27,7 +27,6 @@ export default {
   },
   async putTodo({ commit }, editData) {
     try {
-      console.log(editData)
       const res = await axios.put(API_URL + `/${editData.id}`, {
         title: editData.title,
         body: editData.body


### PR DESCRIPTION
# 行なったこと

## TodoDialog.vue

### putTodoButtonの作成
タイトル(title)、内容(body)項目を入力し、送信ボタンを押すと、入力したデータがpostTodoに渡されるようにしました。その後、title、bodyに空文字列を代入します。

### 項目が空白の場合、送信ボタンを押せないようにした
<v-btn>に:disabledオプションを追加して、title、bodyが空の場合はボタンを押すことができないようにしました。

### 各項目が空白の場合、エラーを表示するようにした
<v-text-field>に:rulesオプションを追加しtitle、またbodyが空の場合、インプットフォームにエラーを表示するようにしました。

# Todoアプリ
![putTodo](https://user-images.githubusercontent.com/46712701/61788758-de7d9e00-ae4d-11e9-94fb-d1f8039cefd2.gif)

# 問題発生
Todoの編集をしても、更新日時が変わらず、リロードをしたら変更されます。
![putTodofail](https://user-images.githubusercontent.com/46712701/61789071-b3e01500-ae4e-11e9-826f-6c6d0d28cc07.gif)

## 原因
`mutations.updateTodo`で`state.todos.updatedAt`を変更していないので、クライアントで表示されるTodoは変更されておらず、リロードで変更されるのは、`get`リクエストでDB内のTodoを読み込んで新たにセットされるので、更新日時も変わっているものと思います。

## 解決
別ブランチにて、`mutations.updateTodo`を修正します。