### PR TITLE
Feature/【修正】mutations.updateTodoでupdatedAtも更新するよう変更

### DIFF
--- a/client/src/store/mutations.js
+++ b/client/src/store/mutations.js
@@ -9,5 +9,6 @@ export default {
     const updateIndex = state.todos.findIndex(todo => editData.id === todo.id);
     state.todos[updateIndex].title = editData.title;
     state.todos[updateIndex].body = editData.body;
+    state.todos[updateIndex].updatedAt = editData.updatedAt;
   }
 };

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -1,5 +1,4 @@
 import mutations from "@/store/mutations";
-import moment from "moment";
 
 const state = {
   todos: []
@@ -13,8 +12,8 @@ class Todo {
     this.title = title;
     this.body = body;
     this.completed = false;
-    this.createdAt = moment().format("YYYY年 MM月 Do(ddd), kk時mm分 ");
-    this.updatedAt = moment().format("YYYY年 MM月 Do(ddd), kk時mm分 ");
+    this.createdAt = new Date();
+    this.updatedAt = new Date();
   }
 }
 
@@ -53,10 +52,12 @@ describe("TEST mutations.js", () => {
 
     mutations.updateTodo(state, editData);
 
+
     expect(state.todos[0]).toMatchObject(
       { id: editData.id },
       { title: editData.title },
       { body: editData.body }
     );
+    expect(Math.max(state.todos[0].createdAt)).toBeLessThan(Math.max(state.todos[0].updatedAt))
   });
 });

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -47,11 +47,11 @@ describe("TEST mutations.js", () => {
     const editData = {
       id: 1,
       title: "update title",
-      body: "update text"
+      body: "update text",
+      updatedAt: new Date()
     };
 
     mutations.updateTodo(state, editData);
-
 
     expect(state.todos[0]).toMatchObject(
       { id: editData.id },


### PR DESCRIPTION
# 行なったこと

## 1. テスト項目追加

`updateTodo`が成功した場合、`updatedAt`は`createdAt`より日付の数値が大きくなっているはずなのでテストでチェック


### Math.maxを使った理由
`.toBeLessThan`は数値型のみ使用できるテスト構文ですが、`new Date()`はオブジェクト型なので使用する事ができません。
なので`Math.max`がnew Dateを数値に変換するのを利用しました。

# テスト結果
<img width="463" alt="スクリーンショット 2019-07-24 22 42 46" src="https://user-images.githubusercontent.com/46712701/61798538-6a9ac000-ae64-11e9-8913-dabf754a6abd.png">

# Todoアプリ
![putTodo succ](https://user-images.githubusercontent.com/46712701/61798602-8b631580-ae64-11e9-974d-16aefc6c29cb.gif)

