### PR TITLE
Feature/mutations.deleteTodoの作成

### DIFF
--- a/client/src/store/mutations.js
+++ b/client/src/store/mutations.js
@@ -10,5 +10,9 @@ export default {
     state.todos[updateIndex].title = editData.title;
     state.todos[updateIndex].body = editData.body;
     state.todos[updateIndex].updatedAt = editData.updatedAt;
+  },
+  deleteTodo(state, id) {
+    const deleteIndex = state.todos.findIndex(todo => id === todo.id);
+    state.todos.splice(deleteIndex, 1);
   }
 };

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -62,7 +62,7 @@ describe("TEST mutations.js", () => {
       Math.max(state.todos[0].updatedAt)
     );
   });
-  it("removeTodoは、指定したIDの値と合致するTodo１件を削除する", () => {
+  it("deleteTodoは、指定したIDの値と合致するTodo１件を削除する", () => {
     const oldTodos = state.todos.slice();
     const id = 1;
 

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -58,6 +58,16 @@ describe("TEST mutations.js", () => {
       { title: editData.title },
       { body: editData.body }
     );
-    expect(Math.max(state.todos[0].createdAt)).toBeLessThan(Math.max(state.todos[0].updatedAt))
+    expect(Math.max(state.todos[0].createdAt)).toBeLessThan(
+      Math.max(state.todos[0].updatedAt)
+    );
+  });
+  it("removeTodoは、指定したIDの値と合致するTodo１件を削除する", () => {
+    const oldTodos = state.todos.slice();
+    const id = 1;
+
+    mutations.deleteTodo(state, id);
+
+    expect(state.todos[0]).not.toEqual(oldTodos[0]);
   });
 });


### PR DESCRIPTION
# 行なった事

## 1. mutations.deleteTodoのテスト作成

### テスト内容

- `deleteTodoは、指定したIDの値と合致するTodo１件を削除する`
actionsから渡されるデータを元に、合致したIDのTodo１件が適切に削除されているかチェックします。

## 2. mutations.deleteTodoの作成

渡されるデータ

- id
この値を元に、Todo一件を検索、会得します。

# テスト結果
<img width="499" alt="スクリーンショット 2019-07-25 16 42 28" src="https://user-images.githubusercontent.com/46712701/61855555-38886d00-aefb-11e9-95ef-70928679747d.png">
