### PR TITLE
Feature/【DELETE】actions.deleteTodoの作成

### DIFF
--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -27,12 +27,21 @@ export default {
   },
   async putTodo({ commit }, editData) {
     try {
+      // 別ブランチででAPI_URLをdeleteTodoと同じ形に修正
       const res = await axios.put(API_URL + `/${editData.id}`, {
         title: editData.title,
         body: editData.body
       });
       const todoData = res.data;
       commit("updateTodo", todoData);
+    } catch (error) {
+      throw error;
+    }
+  },
+  async deleteTodo({ commit }, deleteId) {
+    try {
+      await axios.delete(`${API_URL}/${deleteId}`);
+      commit("deleteTodo", deleteId);
     } catch (error) {
       throw error;
     }

--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -27,7 +27,7 @@ export default {
   },
   async putTodo({ commit }, editData) {
     try {
-      // 別ブランチででAPI_URLをdeleteTodoと同じ形に修正
+      // TODO: 別ブランチででAPI_URLをdeleteTodoと同じ形に修正
       const res = await axios.put(API_URL + `/${editData.id}`, {
         title: editData.title,
         body: editData.body

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -111,4 +111,11 @@ describe("TEST acitons.js", () => {
     expect(url).toBe(`http://localhost:8040/api/todos/${deleteId}`);
     expect(commit).toHaveBeenCalledWith("deleteTodo", 1);
   });
+  it("actions.deleteTodoのエラー発生時テスト", async () => {
+    mockError = true;
+
+    await expect(actions.deleteTodo({ commit: jest.fn() })).rejectss.toThrow(
+      "Error"
+    );
+  });
 });

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -102,4 +102,13 @@ describe("TEST acitons.js", () => {
       "Error"
     );
   });
+  it("actions.deleteTodoは、渡されたidと合致するTodo一件を削除し、渡されたidをmutations.deleteTodoに渡す", async () => {
+    const commit = jest.fn();
+    const deleteId = 1;
+
+    await actions.deleteTodo({ commit }, deleteId);
+
+    expect(url).toBe(`http://localhost:8040/api/todos/${deleteId}`);
+    expect(commit).toHaveBeenCalledWith("deleteTodo", 1);
+  });
 });

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -114,7 +114,7 @@ describe("TEST acitons.js", () => {
   it("actions.deleteTodoのエラー発生時テスト", async () => {
     mockError = true;
 
-    await expect(actions.deleteTodo({ commit: jest.fn() })).rejectss.toThrow(
+    await expect(actions.deleteTodo({ commit: jest.fn() })).rejects.toThrow(
       "Error"
     );
   });

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -45,6 +45,7 @@ jest.mock("axios", () => ({
   }
 }));
 
+// TODO:const commit =jest.fn()は一回一回作成せずに統一して使用できるので別ブランチでリファクタリング
 describe("TEST acitons.js", () => {
   afterEach(() => {
     mockError = false;
@@ -59,6 +60,7 @@ describe("TEST acitons.js", () => {
   it("acitons.fetchTodosのエラー発生時テスト", async () => {
     mockError = true;
 
+    // TODO:fetchTodosの第二引数で渡してる{}は不要なので別ブランチで削除
     await expect(actions.fetchTodos({ commit: jest.fn() }, {})).rejects.toThrow(
       "Error"
     );

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -33,6 +33,15 @@ jest.mock("axios", () => ({
       body = _body;
       resolve({ data: true });
     });
+  },
+  delete: _url => {
+    return new Promise(resolve => {
+      if (mockError) {
+        throw new Error("Error");
+      }
+      url = _url;
+      resolve({ data: 1 });
+    });
   }
 }));
 


### PR DESCRIPTION
# 行なった事

## 1. actions.deleteTodoのテスト作成

### モック関数の追加(`delete`)
deleteTodoはdeleteリクエスト時、引数にURLのみ渡すので、そのチェックを行います。

### テスト内容

- `actions.deleteTodoは、渡されたidと合致するTodo一件を削除し、渡されたidをmutations.deleteTodoに渡す`
deleteTodoが`delete`リクエストを実行した時、渡したURLに間違いがないか等チェックします。

- `actions.deleteTodoのエラー発生時テスト`
deleteTodoが`delete`リクエストに失敗した時、適切なエラーを返すかチェックします。

## 2. actions.deleteTodoの作成
`delete`リクエストを実行、指定したAPIアドレスの末尾に`id`を加え、特定のTodoを会得します。
会得したTodoは削除され、そのままidの値を`mutations.deleteTodo`に渡します。

# テスト結果
<img width="499" alt="スクリーンショット 2019-07-25 19 31 25" src="https://user-images.githubusercontent.com/46712701/61867750-da678400-af12-11e9-9d74-7c01dbd084e4.png">
