### PR TITLE
Feature/【DELETE】DeleteDialogで削除ボタンを押した時、指定したTodo一件が削除される

### DIFF
--- a/client/src/components/Todo/Todo.vue
+++ b/client/src/components/Todo/Todo.vue
@@ -3,7 +3,7 @@
     <v-container xs12 sm6 md3>
       <v-card hover class="card" width="200px" @click="showTodoDialog()">
         <v-layout justify-end class="closeBox">
-          <v-btn @click.stop class="closeBtn" fab small depressed flat>
+          <v-btn @click.stop="showDeleteDialog()" class="closeBtn" fab small depressed flat>
             <v-icon>far fa-times-circle</v-icon>
           </v-btn>
         </v-layout>
@@ -53,6 +53,10 @@ export default {
   methods: {
     showTodoDialog() {
       this.$refs.todoDialog.open();
+      this.selectedTodo = this.todo;
+    },
+    showDeleteDialog() {
+      this.$refs.deleteDialog.open();
       this.selectedTodo = this.todo;
     }
   }

--- a/client/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/client/src/components/Todo/dialogs/DeleteDialog.vue
@@ -7,7 +7,7 @@
       <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn color="red" @click="dummy = !dummy" flat>はい</v-btn>
-        <v-btn color="gray" flat @click="dummy = !dummy">いいえ</v-btn>
+        <v-btn color="gray" flat @click="close()">いいえ</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -34,7 +34,7 @@ export default {
     open() {
       this.isOpen = true;
     },
-    cloce() {
+    close() {
       this.isOpen = false;
     }
   }

--- a/client/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/client/src/components/Todo/dialogs/DeleteDialog.vue
@@ -6,7 +6,7 @@
       </v-card-title>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="red" @click="dummy = !dummy" flat>はい</v-btn>
+        <v-btn color="red" @click="deleteTodoButton()" flat>はい</v-btn>
         <v-btn color="gray" flat @click="close()">いいえ</v-btn>
       </v-card-actions>
     </v-card>
@@ -14,6 +14,7 @@
 </template>
 
 <script>
+import { mapActions } from "vuex";
 export default {
   props: {
     todo: {
@@ -28,16 +29,20 @@ export default {
   data() {
     return {
       isOpen: false,
-      dummy: false
     };
   },
 
   methods: {
+    ...mapActions(["deleteTodo"]),
     open() {
       this.isOpen = true;
     },
     close() {
       this.isOpen = false;
+    },
+    deleteTodoButton() {
+      this.deleteTodo(this.todo.id);
+      this.close()
     }
   }
 };

--- a/client/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/client/src/components/Todo/dialogs/DeleteDialog.vue
@@ -37,6 +37,6 @@ export default {
     cloce() {
       this.isOpen = false;
     }
-  },
+  }
 };
 </script>

--- a/client/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/client/src/components/Todo/dialogs/DeleteDialog.vue
@@ -1,6 +1,9 @@
 <template>
   <v-dialog v-model="isOpen" scrollable max-width="50%">
     <v-card>
+      <v-layout align-center>
+        <v-alert v-model="isError" color="error" icon="warning" outline dismissible>{{ errorMsg }}</v-alert>
+      </v-layout>
       <v-card-title>
         <strong>"{{ todo.title }}"</strong>を削除しますか？
       </v-card-title>
@@ -29,6 +32,8 @@ export default {
   data() {
     return {
       isOpen: false,
+      isError: false,
+      errorMsg: ""
     };
   },
 
@@ -45,7 +50,8 @@ export default {
         await this.deleteTodo(this.todo.id);
         this.close();
       } catch (error) {
-        throw error.message
+        this.isError = true;
+        this.errorMsg = error.message;
       }
     }
   }

--- a/client/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/client/src/components/Todo/dialogs/DeleteDialog.vue
@@ -28,7 +28,7 @@ export default {
   },
   data() {
     return {
-      isOpen: false,
+      isOpen: false
     };
   },
 
@@ -42,7 +42,7 @@ export default {
     },
     deleteTodoButton() {
       this.deleteTodo(this.todo.id);
-      this.close()
+      this.close();
     }
   }
 };

--- a/client/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/client/src/components/Todo/dialogs/DeleteDialog.vue
@@ -28,7 +28,7 @@ export default {
   },
   data() {
     return {
-      isOpen: false
+      isOpen: false,
     };
   },
 
@@ -40,9 +40,13 @@ export default {
     close() {
       this.isOpen = false;
     },
-    deleteTodoButton() {
-      this.deleteTodo(this.todo.id);
-      this.close();
+    async deleteTodoButton() {
+      try {
+        await this.deleteTodo(this.todo.id);
+        this.close();
+      } catch (error) {
+        throw error.message
+      }
     }
   }
 };

--- a/client/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/client/src/components/Todo/dialogs/DeleteDialog.vue
@@ -19,9 +19,10 @@ export default {
     todo: {
       id: Number,
       title: String,
-      text: String,
-      date: String,
-      completed: Boolean
+      body: String,
+      completed: Boolean,
+      createdAt: String,
+      updatedAt: String
     }
   },
   data() {
@@ -30,6 +31,7 @@ export default {
       dummy: false
     };
   },
+
   methods: {
     open() {
       this.isOpen = true;

--- a/client/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/client/src/components/Todo/dialogs/DeleteDialog.vue
@@ -29,6 +29,14 @@ export default {
       isOpen: false,
       dummy: false
     };
-  }
+  },
+  methods: {
+    open() {
+      this.isOpen = true;
+    },
+    cloce() {
+      this.isOpen = false;
+    }
+  },
 };
 </script>


### PR DESCRIPTION
# 行なった事

## 1. DeleteDialogの表示/非表示

`DeleteDialog.vue`に`open`と`close`メソッドを作成、openは`Todo.vue`から`$refs`経由で操作します。

## 2. deleteTodoButtonの作成

DeleteDialogの`はい`ボタンを押すと、削除したいTodoのidが`actions.deleteTodo`に渡されます。エラーが発生した場合は、エラー表示が出ます
<img width="1264" alt="スクリーンショット 2019-07-25 20 06 22" src="https://user-images.githubusercontent.com/46712701/61869917-c1ad9d00-af17-11e9-97f9-14ca2f957000.png">


# Todoアプリ
![deleteTodo sec](https://user-images.githubusercontent.com/46712701/61869444-99716e80-af16-11e9-95ae-524d9511c6b2.gif)
