### PR TITLE
Feature/mutations.switchCompletedの作成

### DIFF
--- a/client/src/store/mutations.js
+++ b/client/src/store/mutations.js
@@ -14,5 +14,9 @@ export default {
   deleteTodo(state, id) {
     const deleteIndex = state.todos.findIndex(todo => id === todo.id);
     state.todos.splice(deleteIndex, 1);
+  },
+  switchCompleted(state, id) {
+    const switchIndex = state.todos.findIndex(todo => id === todo.id);
+    state.todos[switchIndex].completed = !state.todos[switchIndex].completed;
   }
 };

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -70,4 +70,11 @@ describe("TEST mutations.js", () => {
 
     expect(state.todos[0]).not.toEqual(oldTodos[0]);
   });
+  it("switchCompletedは、指定したIDの値と合致するTodo１件のcompletedに入っている真偽値を反転する", () => {
+    const id = 2;
+
+    mutations.switchCompleted(state.id);
+
+    expect(state.todos[0]).toBe(true);
+  });
 });

--- a/client/tests/unit/store/mutations.spec.js
+++ b/client/tests/unit/store/mutations.spec.js
@@ -73,8 +73,8 @@ describe("TEST mutations.js", () => {
   it("switchCompletedは、指定したIDの値と合致するTodo１件のcompletedに入っている真偽値を反転する", () => {
     const id = 2;
 
-    mutations.switchCompleted(state.id);
+    mutations.switchCompleted(state, id);
 
-    expect(state.todos[0]).toBe(true);
+    expect(state.todos[0].completed).toBe(true);
   });
 });


### PR DESCRIPTION
# 行なったこと

## 1. mutations.switchCompletedの作成

### テスト内容

- `switchCompletedは、指定したIDの値と合致するtodo１件のcompletedに入っている真偽値を反転する`
指定したIDのcompletedが反転しているかどうかチェック(completedのデフォルトの値はfalseになっていて現状completedの操作はできないので反転したら`true`になっている)

## 2. mutationc.switchCompletedの作成
渡されたidと合致するTodoのcompletedを反転させます

# テスト結果
<img width="487" alt="スクリーンショット 2019-07-25 22 37 48" src="https://user-images.githubusercontent.com/46712701/61878888-dea09b00-af2c-11e9-874f-936306389346.png">
