### PR TITLE
Feature/【PUT】actions.switchCompleteの作成

### DIFF
--- a/client/src/store/actions.js
+++ b/client/src/store/actions.js
@@ -45,5 +45,15 @@ export default {
     } catch (error) {
       throw error;
     }
+  },
+  async switchCompleted({ commit }, switchData) {
+    try {
+      await axios.put(`${API_URL}/${switchData.id}`, {
+        completed: switchData.completed
+      });
+      commit("switchCompleted", switchData.id);
+    } catch (error) {
+      throw error;
+    }
   }
 };

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -120,4 +120,14 @@ describe("TEST acitons.js", () => {
       "Error"
     );
   });
+  it("actions.switchCompletedは、渡されたidと合致するTodo一件のcompletedの真偽値を反転し、渡されたidをmutations.switchCompletedに渡す", async () => {
+    const commit = jest.fn();
+    const switchId = 2;
+
+    await actions.switchCompleted({ commit }, switchId);
+
+    expect(url).toBe(`http://localhost:8040/api/todos/${switchId}`);
+    expect(body).toHaveBeenCalledWith({ completed: true });
+    expect(commit).toHaveBeenCalledWith("switchCompleted", 2);
+  });
 });

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -122,19 +122,22 @@ describe("TEST acitons.js", () => {
   });
   it("actions.switchCompletedは、渡されたidと合致するTodo一件のcompletedの真偽値を反転し、渡されたidをmutations.switchCompletedに渡す", async () => {
     const commit = jest.fn();
-    const switchId = 2;
+    const switchData = {
+      id: 1,
+      completed: true
+    };
 
-    await actions.switchCompleted({ commit }, switchId);
+    await actions.switchCompleted({ commit }, switchData);
 
-    expect(url).toBe(`http://localhost:8040/api/todos/${switchId}`);
-    expect(body).toHaveBeenCalledWith({ completed: true });
-    expect(commit).toHaveBeenCalledWith("switchCompleted", 2);
+    expect(url).toBe(`http://localhost:8040/api/todos/${switchData.id}`);
+    expect(body).toEqual({ completed: true });
+    expect(commit).toHaveBeenCalledWith("switchCompleted", 1);
   });
   it("actions.switchCompletedのエラー発生時テスト", async () => {
     mockError = true;
 
     await expect(
-      actions.switchCompleted({ commit: jest.fn() })
+      actions.switchCompleted({ commit: jest.fn() }, {})
     ).rejects.toThrow("Error");
   });
 });

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -130,4 +130,11 @@ describe("TEST acitons.js", () => {
     expect(body).toHaveBeenCalledWith({ completed: true });
     expect(commit).toHaveBeenCalledWith("switchCompleted", 2);
   });
+  it("actions.switchCompletedのエラー発生時テスト", async () => {
+    mockError = true;
+
+    await expect(
+      actions.switchCompleted({ commit: jest.fn() })
+    ).rejects.toThrow("Error");
+  });
 });

--- a/client/tests/unit/store/actions.spec.js
+++ b/client/tests/unit/store/actions.spec.js
@@ -120,7 +120,7 @@ describe("TEST acitons.js", () => {
       "Error"
     );
   });
-  it("actions.switchCompletedは、渡されたidと合致するTodo一件のcompletedの真偽値を反転し、渡されたidをmutations.switchCompletedに渡す", async () => {
+  it("actions.switchCompletedは、渡されたidと合致するTodo一件のcompletedの真偽値を変更し、渡されたidをmutations.switchCompletedに渡す", async () => {
     const commit = jest.fn();
     const switchData = {
       id: 1,


### PR DESCRIPTION
# 行なったこと

## 1. actions.switchCompletedの作成

モック関数は`put`を利用するので、今回追加はありません

### テスト内容

- `actions.switchCompletedは、渡されたidと合致するTodo一件のcompletedの真偽値を変更し、渡されたidをmutations.switchCompletedに渡す`
switchCompletedが`put`リクエストを実行した時、渡したURL、データに間違いがないかチェックします

- `actions.switchCompletedのエラー発生時テスト`
switchCompletedが`put`リクエストに失敗した時、適切なエラーを返すかチェックします。

## 2. actions.switchCompletedの作成
`put`リクエストを実行、指定したAPIアドレスの末尾に`id`を加え、特定のTodoを検索、会得します。
会得したTodoのcompletedに入っている真偽値を書き換え、そのままidを`mutations.switchCompleted`に渡します

# テスト結果
<img width="481" alt="スクリーンショット 2019-07-26 9 20 41" src="https://user-images.githubusercontent.com/46712701/61917209-f99ff900-af86-11e9-9b4e-fc98fce691f6.png">
