### PR TITLE
Feature/クリックしたチェックボックスを切り替える

### DIFF
--- a/client/src/components/Todo/Todo.vue
+++ b/client/src/components/Todo/Todo.vue
@@ -48,7 +48,7 @@ export default {
   },
   data() {
     return {
-      selectedTodo: {}
+      selectedTodo: {},
     };
   },
   components: {
@@ -74,8 +74,7 @@ export default {
         };
         await this.switchCompleted(switchData);
       } catch (error) {
-        this.$parent.isError = true;
-        this.$parent.errorMsg = error.message;
+        this.$emit("showError", error.message);
       }
     }
   }

--- a/client/src/components/Todo/Todo.vue
+++ b/client/src/components/Todo/Todo.vue
@@ -74,7 +74,8 @@ export default {
         };
         await this.switchCompleted(switchData);
       } catch (error) {
-        throw error;
+        this.$parent.isError = true;
+        this.$parent.errorMsg = error;
       }
     }
   }

--- a/client/src/components/Todo/Todo.vue
+++ b/client/src/components/Todo/Todo.vue
@@ -10,7 +10,11 @@
 
         <v-layout align-center justify-center class="card-inside">
           <v-flex xs2 grow>
-            <v-checkbox class="checkbox" :value="todo.completed" @click.stop></v-checkbox>
+            <v-checkbox
+              class="checkbox"
+              :value="todo.completed"
+              @click.stop="switchCompletedButton()"
+            ></v-checkbox>
           </v-flex>
           <v-flex>
             <v-list-tile-action>
@@ -30,6 +34,7 @@
 <script>
 import TodoDialog from "./dialogs/TodoDialog.vue";
 import DeleteDialog from "./dialogs/DeleteDialog.vue";
+import { mapActions } from "vuex";
 export default {
   props: {
     todo: {
@@ -51,6 +56,7 @@ export default {
     appDeleteDialog: DeleteDialog
   },
   methods: {
+    ...mapActions(["switchCompleted"]),
     showTodoDialog() {
       this.$refs.todoDialog.open();
       this.selectedTodo = this.todo;
@@ -58,6 +64,18 @@ export default {
     showDeleteDialog() {
       this.$refs.deleteDialog.open();
       this.selectedTodo = this.todo;
+    },
+    async switchCompletedButton() {
+      try {
+        const invertedCompleted = !this.todo.completed;
+        const switchData = {
+          id: this.todo.id,
+          completed: invertedCompleted
+        };
+        await this.switchCompleted(switchData);
+      } catch (error) {
+        throw error;
+      }
     }
   }
 };

--- a/client/src/components/Todo/Todo.vue
+++ b/client/src/components/Todo/Todo.vue
@@ -75,7 +75,7 @@ export default {
         await this.switchCompleted(switchData);
       } catch (error) {
         this.$parent.isError = true;
-        this.$parent.errorMsg = error;
+        this.$parent.errorMsg = error.message;
       }
     }
   }

--- a/client/src/components/Todo/Todos.vue
+++ b/client/src/components/Todo/Todos.vue
@@ -1,5 +1,10 @@
 <template>
   <div>
+    <v-layout>
+      <v-flex md12>
+        <v-alert v-model="isError" color="error" icon="warning" outline dismissible>{{ errorMsg }}</v-alert>
+      </v-flex>
+    </v-layout>
     <v-layout row wrap justify-center>
       <app-todo v-for="todo in todos" :key="todo.id" :todo="todo" />
     </v-layout>
@@ -9,6 +14,12 @@
 <script>
 import Todo from "../../components/Todo/Todo.vue";
 export default {
+  data () {
+    return {
+      isError: false,
+      errorMsg: ""
+    }
+  },
   components: {
     appTodo: Todo
   },

--- a/client/src/components/Todo/Todos.vue
+++ b/client/src/components/Todo/Todos.vue
@@ -14,11 +14,11 @@
 <script>
 import Todo from "../../components/Todo/Todo.vue";
 export default {
-  data () {
+  data() {
     return {
       isError: false,
       errorMsg: ""
-    }
+    };
   },
   components: {
     appTodo: Todo

--- a/client/src/components/Todo/Todos.vue
+++ b/client/src/components/Todo/Todos.vue
@@ -6,7 +6,12 @@
       </v-flex>
     </v-layout>
     <v-layout row wrap justify-center>
-      <app-todo v-for="todo in todos" :key="todo.id" :todo="todo"  @showError="showError($event, errorMsg)"/>
+      <app-todo
+        v-for="todo in todos"
+        :key="todo.id"
+        :todo="todo"
+        @showError="showError($event, errorMsg)"
+      />
     </v-layout>
   </div>
 </template>
@@ -17,16 +22,15 @@ export default {
   data() {
     return {
       isError: false,
-      errorMsg: "",
+      errorMsg: ""
     };
   },
   components: {
     appTodo: Todo
   },
   methods: {
-    showError(errorMsg){
-      this.isError = true,
-      this.errorMsg = errorMsg
+    showError(errorMsg) {
+      (this.isError = true), (this.errorMsg = errorMsg);
     }
   },
   computed: {

--- a/client/src/components/Todo/Todos.vue
+++ b/client/src/components/Todo/Todos.vue
@@ -6,7 +6,7 @@
       </v-flex>
     </v-layout>
     <v-layout row wrap justify-center>
-      <app-todo v-for="todo in todos" :key="todo.id" :todo="todo" />
+      <app-todo v-for="todo in todos" :key="todo.id" :todo="todo"  @showError="showError($event, errorMsg)"/>
     </v-layout>
   </div>
 </template>
@@ -17,13 +17,18 @@ export default {
   data() {
     return {
       isError: false,
-      errorMsg: ""
+      errorMsg: "",
     };
   },
   components: {
     appTodo: Todo
   },
-  methods: {},
+  methods: {
+    showError(errorMsg){
+      this.isError = true,
+      this.errorMsg = errorMsg
+    }
+  },
   computed: {
     todos() {
       return this.$store.getters.todos;

--- a/client/src/components/Todo/dialogs/TodoDialog.vue
+++ b/client/src/components/Todo/dialogs/TodoDialog.vue
@@ -23,7 +23,12 @@
       </v-card-text>
       <v-spacer></v-spacer>
       <v-card-actions>
-        <v-checkbox v-if="!isUpdate" class="modal-checkbox" :value="todo.completed" @click.stop></v-checkbox>
+        <v-checkbox
+          v-if="!isUpdate"
+          class="modal-checkbox"
+          :value="todo.completed"
+          @click.stop="switchCompletedButton()"
+        ></v-checkbox>
         <v-layout row wrap justify-end>
           <v-btn v-if="!isUpdate" color="success" @click="editorOpen()" outline>編集</v-btn>
           <v-btn v-if="isUpdate" color="error" @click="editorClose()">キャンセル</v-btn>
@@ -80,7 +85,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions(["putTodo"]),
+    ...mapActions(["putTodo", "switchCompleted"]),
     open() {
       this.isOpen = true;
     },
@@ -103,6 +108,19 @@ export default {
         this.title = "";
         this.body = "";
         this.editorClose();
+      } catch (error) {
+        this.isError = true;
+        this.errorMsg = error.message;
+      }
+    },
+    async switchCompletedButton() {
+      try {
+        const invertedCompleted = !this.todo.completed;
+        const switchData = {
+          id: this.todo.id,
+          completed: invertedCompleted
+        };
+        await this.switchCompleted(switchData);
       } catch (error) {
         this.isError = true;
         this.errorMsg = error.message;


### PR DESCRIPTION
# 行なったこと

## Todo.vue

### switchCompletedButtonの作成

チェックボックスをクリックすると、Todoのidと今completedに入っている真偽値を反転させた値を`actions.switchCompleted`に送ります

#### エラーの場合
Todos.vueにエラーフォームを作成し、`this.$emit`でTodo.vueから操作できるようにしました。

- なぜTodo.vueにエラーフォームを置かないのか
Todo.vueはTodoを一個ずつ表示するコンポーネントなので、エラーフォームを作成したらTodo一個につき一つフォームが表示されるからです。

## TodoDialog.vue

### switchCompletedButtonの作成

チェックボックスをクリックすると、Todoのidと今completedに入っている真偽値を反転させた値を`actions.switchCompleted`に送ります。
こちらのエラーは #27 で作成したエラーフォームを使用します

# Todoアプリ
![switchComp](https://user-images.githubusercontent.com/46712701/61920369-48a05b00-af94-11e9-9b17-a90c97d90d29.gif)
 